### PR TITLE
feat(reverse-proxy): add Dockerfile and nginx.conf for reverse proxy …

### DIFF
--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -1,0 +1,27 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+error_log /dev/stdout debug;
+
+http {
+
+    sendfile on;
+
+    upstream motor {
+        server motor-emparejamiento:5000 max_fails=0;
+    }
+
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Host $server_name;
+
+    server {
+        listen 8080;
+        location /candidatos {
+            proxy_pass         http://motor;
+            proxy_next_upstream error timeout http_503;
+        }
+    }
+
+}


### PR DESCRIPTION
feat(reverse-proxy): add Dockerfile and nginx.conf for reverse proxy configuration

The Dockerfile and nginx.conf files are added to the reverse-proxy directory. The Dockerfile is used to build the reverse proxy image, while the nginx.conf file contains the configuration for the reverse proxy. The reverse proxy is configured to listen on port 8080 and forward requests to the motor-emparejamiento service on port 5000. The proxy headers are also set to preserve the original client IP and host information.